### PR TITLE
re-use http client for every pipline

### DIFF
--- a/2017-07-29/azqueue/zc_pipeline.go
+++ b/2017-07-29/azqueue/zc_pipeline.go
@@ -81,11 +81,12 @@ func newDefaultHTTPClient() *http.Client {
 	}
 }
 
+var pipelineHTTPClient = newDefaultHTTPClient()
 
 func newDefaultHTTPClientFactory() pipeline.Factory {
 	return pipeline.FactoryFunc(func(next pipeline.Policy, po *pipeline.PolicyOptions) pipeline.PolicyFunc {
 		return func(ctx context.Context, request pipeline.Request) (pipeline.Response, error) {
-			r, err := newDefaultHTTPClient().Do(request.WithContext(ctx))
+			r, err := pipelineHTTPClient.Do(request.WithContext(ctx))
 			if err != nil {
 				err = pipeline.NewError(err, "HTTP request failed")
 			}


### PR DESCRIPTION
Similar to Azure Pipeline core, re-use a single http client connection: https://github.com/Azure/azure-pipeline-go/blob/master/pipeline/core.go#L201.  This is safe since since the clients and transports are safe for concurrent use per the go http package: https://golang.org/pkg/net/http/.

Fixes #8 